### PR TITLE
Sanitize repository URLs

### DIFF
--- a/lib/any_good.rb
+++ b/lib/any_good.rb
@@ -28,7 +28,7 @@ class AnyGood
     }
 
     repo_id = [data[:gem]['source_code_uri'], data[:gem]['homepage_uri']]
-      .grep(GITHUB_URI_PATTERN).first&.sub(GITHUB_URI_PATTERN, '')
+      .grep(GITHUB_URI_PATTERN).first&.sub(GITHUB_URI_PATTERN, '')&.chomp '/'
 
     if repo_id
       data.merge!(


### PR DESCRIPTION
Before:

```sh
$ exe/any_good rubocop

[..] octokit-4.8.0/lib/octokit/repository.rb:92:in `raise_invalid_repository!': "bbatsov/rubocop/" is invalid as a repository  identifier. Use the repo/user
(String) format, or the repository ID (Integer), or a hash containing :repo and :user keys. (Octokit::InvalidRepository
```

After:
```sh
$ exe/any_good rubocop

Downloads: 119,567,948
```
[etc.]