### PR TITLE
Add note about RVM usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ $ gem install any_good
 $ any_good <gem_name>
 ```
 
+### RVM
+
+Under RVM your any_good command may only be available under the ruby you install any_good into. To prevent this, and to prevent gem conflicts, install any_good into a dedicated gemset and create wrapper scripts:
+
+```
+rvm default@any_good --create do gem install any_good
+rvm wrapper default@any_good --no-prefix any_good
+```
+
 ## Why?
 
 I find myself constantly repeating this process for some new gems I spotted somewhere: going to


### PR DESCRIPTION
Why:

* Installs the gem into an isolated gemset
* Makes the executable available system-wide
* Avoids gem conflicts
* Removes the need to install the gem in every gemset you'd like to use it in

This change addresses the need by:

* Adds a few lines in the README which describe how to install the gem into an isolated gemset & how to make its executable available system-wide (i.e. from within any gemset)

Reference Links:

* Shamelessly yanked from https://github.com/sj26/mailcatcher/blob/master/README.md#rvm