### PR TITLE
Fix singular v plural inflection of time units

### DIFF
--- a/lib/any_good/meters.rb
+++ b/lib/any_good/meters.rb
@@ -48,7 +48,7 @@ class AnyGood
       when Date, Time
         diff = TimeMath.measure(value, Time.now)
         unit, num = diff.detect { |_, v| !v.zero? }
-        "#{num} #{unit} ago"
+        "#{num} #{num == 1 ? unit.to_s.chomp('s') : unit} ago"
       else
         fail ArgumentError, "Unformattable #{value.inspect}"
       end


### PR DESCRIPTION
"1 days ago" should read "1 day ago", etc..